### PR TITLE
Fixed DRUM4_16_u and DRUM7_16_u

### DIFF
--- a/DRUM4_16_u.v
+++ b/DRUM4_16_u.v
@@ -46,9 +46,9 @@ LOD u2(.in_a(b),.out_a(l2));
 P_Encoder u3(.in_a(l1), .out_a(k1));
 P_Encoder u4(.in_a(l2), .out_a(k2));
 
-ux_16_3 u5(.in_a(a), .select(k1), .out(m));
+Mux_16_3 u5(.in_a(a), .select(k1), .out(m));
 
-ux_16_3 u6(.in_a(b), .select(k2), .out(n));
+Mux_16_3 u6(.in_a(b), .select(k2), .out(n));
 assign p=(k1>3)?k1-3:0;
 assign q=(k2>3)?k2-3:0;
 assign mm=(k1>3)?({1'b1,m,1'b1}):a[3:0];

--- a/DRUM7_16_u.v
+++ b/DRUM7_16_u.v
@@ -30,7 +30,7 @@ Computer-Aided Design (ICCAD). 2015.
 
 */
 
-module DRUM7_17_u(a, b, r);
+module DRUM7_16_u(a, b, r);
 input [15:0]a,b;
 output [31:0]r;
 


### PR DESCRIPTION
Fixes #3 

* DRUM4_16_u.v
  * Fixed mux module instantiation in lines 49 and 51. It was ```ux_16_3```, fixed to ```Mux_16_3```.
* DRUM7_16_u.v
  * Fixed module name in line 33. It was ```DRUM7_17_u```, fixed to ```DRUM7_16_u```.
